### PR TITLE
Refactoring of the render part of the webform component.

### DIFF
--- a/src/Component.php
+++ b/src/Component.php
@@ -112,8 +112,9 @@ class Component {
       $pmid_options[$pmid] = check_plain(t($payment_method->title_generic));
     }
 
-    unset($element['placeholder_info']);
+    unset($element['#theme']);
     $element += array(
+      '#type' => 'container',
       '#tree' => TRUE,
       '#theme_wrappers' => array('container'),
       '#id' => drupal_html_id('paymethod-select-wrapper'),

--- a/src/Component.php
+++ b/src/Component.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Drupal\webform_paymethod_select;
+
+use \Drupal\little_helpers\Webform\FormState;
+use \Drupal\little_helpers\Webform\Submission;
+
+class Component {
+  protected $component;
+  protected $payment = NULL;
+  public function __construct(array $component) {
+    $this->component = $component;
+    $this->payment = self::createPayment($component);
+  }
+
+  /**
+   * Create a payment object based on the component configuration.
+   *
+   * @param array $component
+   *   Weform component array.
+   *
+   * @return \Payment
+   *   Newly created payment object.
+   */
+  protected static function createPayment($component) {
+    $config = $component['extra'] + array(
+      'line_items' => array(),
+      'payment_description' => t('Default Payment'),
+      'currency_code' => 'EUR',
+    );
+
+    $payment = new \Payment(
+      array(
+        'currency_code'   => $config['currency_code'],
+        'description'     => $config['payment_description'],
+        'finish_callback' => 'webform_paymethod_select_payment_finish',
+      )
+    );
+
+    foreach ($config['line_items'] as $line_item) {
+      $payment->setLineItem($line_item);
+    }
+    return $payment;
+  }
+
+  /**
+   * Get the list of available and selected payment methods.
+   *
+   * @param \Drupal\payment_forms\PaymentContextInterface $context
+   *   The payment context used for the alter hook.
+   *
+   * @return array
+   *   List of \PaymentMethod objects keyed by their pmids.
+   */
+  protected function getMethods($context) {
+    $pmids = array_keys(array_filter($this->component['extra']['selected_payment_methods']));
+    $methods = entity_load('payment_method', $pmids);
+    // @TODO Use $payment->context instead?
+    $this->payment->context_data['context'] = $context;
+    if (!empty($methods)) {
+      $methods = $this->payment->availablePaymentMethods($methods);
+    }
+    unset($this->payment->context_data['context']);
+    // @TODO implement  a more straight-forward interface for the alter hook
+    //       ie. use only $methods and $context as arguments.
+    $methods_copy = $methods;
+    drupal_alter('webform_paymethod_select_method_list', $context, $methods_copy, $methods);
+    return $methods;
+  }
+
+  /**
+   * Generate the fieldset for one specific payment method.
+   *
+   * @return array
+   *   Form-API fieldset.
+   */
+  protected function methodForm($method, &$form_state, $context) {
+    $payment = clone $this->payment;
+    $payment->method = $method;
+
+    $element = array(
+      '#type'        => 'fieldset',
+      '#title'       => t($method->title_generic),
+      '#attributes'  => array('class' => array('payment-method-form'), 'data-pmid' => $method->pmid),
+      '#collapsible' => FALSE,
+      '#collapsed'   => FALSE,
+      '#states' => array(
+        'visible' => array(
+          '#payment-method-selector input' => array('value' => (string) $method->pmid),
+        ),
+      ),
+    );
+
+    $form_elements_callback = $method->controller->payment_configuration_form_elements_callback;
+    // @TODO Explicitly pass the payment to the form callback.
+    $form_state['payment'] = $payment;
+    if (function_exists($form_elements_callback) == TRUE) {
+      $element += $form_elements_callback($element, $form_state, $context);
+    }
+    return $element;
+  }
+
+  /** 
+   * Render the webform component.
+   */
+  public function render(&$element, &$form, &$form_state) {
+    $context = new WebformPaymentContext(new FormState($form['#node'], $form, $form_state), $form_state);
+
+    $pmid_options = array();
+    $methods = $this->getMethods($context);
+    foreach($methods as $pmid => $payment_method) {
+      $pmid_options[$pmid] = check_plain(t($payment_method->title_generic));
+    }
+
+    unset($element['placeholder_info']);
+    $element += array(
+      '#tree' => TRUE,
+      '#theme_wrappers' => array('container'),
+      '#id' => drupal_html_id('paymethod-select-wrapper'),
+      '#element_validate' => array('webform_paymethod_select_component_element_validate'),
+      '#cid' => $this->component['cid'],
+    );
+    $element['#attributes']['class'][] = 'paymethod-select-wrapper';
+    $element['payment_method_all_forms'] = array(
+      '#type'        => 'container',
+      '#id'          => 'payment-method-all-forms',
+      '#weight'      => 2,
+      '#attributes'  => array('class' => array('payment-method-all-forms')),
+    );
+
+    if (!count($pmid_options)) {
+      if (!$this->payment->pid && isset($form['actions']['submit'])) {
+        // when no payment method is selected (or available) disable submit
+        // button
+        $form['actions']['submit']['#disabled'] = TRUE;
+      }
+      $element['pmid_title'] = array(
+        '#type'   => 'item',
+        '#title'  => isset($element['#title']) ? $element['#title'] : NULL,
+        '#markup' => t('There are no payment methods, check the options of this webform element to enable methods.'),
+      );
+    }
+    else {
+      reset($pmid_options);
+      $pmid_default = isset($this->payment->method) ? $this->payment->method->pmid : key($pmid_options);
+
+      foreach ($pmid_options as $pmid => $method_name) {
+        $element['payment_methods_all_forms'][$pmid] = $this->methodForm($methods[$pmid], $form_state, $context);
+      }
+
+      $element['payment_method_selector'] = array(
+        '#type'          => 'radios',
+        '#id'            => 'payment-method-selector',
+        '#weight'        => 1,
+        '#title'         => isset($element['#title']) ? $element['#title'] : NULL,
+        '#options'       => $pmid_options,
+        '#default_value' => $pmid_default,
+        '#required'      => $element['#required'],
+        '#attributes'    => array('class' => array('paymethod-select-radios')),
+        '#access'        => count($pmid_options) > 1,
+      );
+    }
+  }
+
+  public function validate(array $element, array &$form_state) {
+    $payment = $this->payment;
+    $values  = drupal_array_get_nested_value($form_state['values'], $element['#parents']);
+    $pmid    = (int) $values['payment_method_selector'];
+
+    $payment->method = $method = entity_load_single('payment_method', $pmid);
+    if ($payment->method->name === 'payment_method_unavailable') {
+      form_error($element, t('Invalid Payment Method selected.'));
+    }
+
+    $method_validate_callback = $method->controller->payment_configuration_form_elements_callback . '_validate';
+    if (function_exists($method_validate_callback)) {
+      // @TODO: pass the payment object directly.
+      $form_state['payment'] = $payment;
+      $method_element = &$element['payment_methods_all_forms'][$pmid];
+      $method_validate_callback($method_element, $form_state);
+    }
+  }
+
+  public function submit(&$form, &$form_state) {
+    $payment = $this->payment;
+    $node = $form['#node'];
+
+    $submission = Submission::load($node->nid, $form_state['values']['details']['sid']);
+    $context = new WebformPaymentContext($submission, $form_state);
+    $payment->context_data['context'] = $context;
+
+    // handle setting the amount value in line items that were configured to
+    // not have a fixed amount
+    foreach ($payment->line_items as $line_item) {
+      if ($line_item->amount_source === 'component') {
+        $amount = $submission->valueByCid($line_item->amount_component);
+        $amount = str_replace(',', '.', $amount);
+        $line_item->amount = (float) $amount;
+      }
+    }
+    $values = $form_state['values']['submitted'][$this->component['cid']];
+    $payment->method = entity_load_single('payment_method', $values['payment_method_selector']);
+    entity_save('payment', $payment);
+
+    // Execute the payment.
+    if ($payment->getStatus()->status == PAYMENT_STATUS_NEW) {
+      $payment->execute();
+    }
+
+    // Set the component value to the $payment->pid - we don't save any payment data.
+    $webform = $submission->webform;
+    $cids = array_keys($webform->componentsByType('paymethod_select'));
+    db_query(
+      "UPDATE {webform_submitted_data} SET data=:pid WHERE nid=:nid AND cid=:cid AND sid=:sid",
+      array(':nid' => $node->nid, ':cid' => $this->component['cid'], ':sid' => $submission->sid, ':pid' => $payment->pid)
+    );
+  }
+}

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -44,6 +44,17 @@ function webform_paymethod_select_payment_access(\Payment $payment) {
 }
 
 /**
+ * Implements hook_theme().
+ */
+function webform_paymethod_select_theme() {
+  $hooks['webform_paymethod_select_placeholder'] = array(
+    'render element' => 'element',
+    'file' => 'webform_paymethod_select.theme.inc',
+  );
+  return $hooks;
+}
+
+/**
  * Implements hook_webform_component_info().
  */
 function webform_paymethod_select_webform_component_info() {

--- a/webform_paymethod_select.module
+++ b/webform_paymethod_select.module
@@ -5,6 +5,7 @@
 
 use \Drupal\webform_paymethod_select\WebformPaymentContext;
 use \Drupal\webform_paymethod_select\PaymentRecurrentController;
+use \Drupal\webform_paymethod_select\Component;
 use \Drupal\little_helpers\Webform\Submission;
 use \Drupal\little_helpers\Webform\FormState;
 use \Drupal\little_helpers\Webform\Webform;
@@ -98,142 +99,12 @@ function webform_paymethod_select_clean_name($controller_name) {
 }
 
 /**
- * Implements hook_element_info().
+ * Element validate function for our webform component.
  */
-function webform_paymethod_select_element_info() {
-  // A payment method selection and configuration element. Every form this
-  // element is used in should have a Payment object in $form_state['payment'].
-  $elements['paymethod_select'] = array(
-    '#input'            => TRUE,
-    '#process'          => array('webform_paymethod_select_form_process'),
-    '#element_validate' => array('webform_paymethod_select_form_process_validate'),
-  );
+function webform_paymethod_select_component_element_validate(array $element, array &$form_state) {
+  $component = $form_state['webform_paymethod_select'][$element['#cid']];
+  $component->validate($element, $form_state);
 
-  return $elements;
-}
-
-/**
- * helper function to preload all forms defined by the individual payment methods
- */
-function _webform_paymethod_select_get_payment_method_form(&$element, &$form_state, PaymentMethod $method, PaymentContextInterface $context) {
-  $form_element_name = webform_paymethod_select_clean_name($method->controller->name);
-
-  $element['payment_method_all_forms'][$form_element_name] = array(
-    '#type'        => 'fieldset',
-    '#id'          => $form_element_name,
-    '#title'       => t($method->title_generic),
-    '#attributes'  => array('class' => array('payment-method-form'),
-			    'data-pmid' => $method->pmid),
-    '#collapsible' => FALSE,
-    '#collapsed'   => FALSE,
-    '#states' => array(
-      'visible' => array(
-        '#payment-method-selector input' => array('value' => (string) $method->pmid),
-      ),
-    ),
-  );
-
-  $form_elements_callback = $method->controller->payment_configuration_form_elements_callback;
-  if (function_exists($form_elements_callback) == TRUE) {
-    $element['payment_method_all_forms'][$form_element_name] += call_user_func($form_elements_callback, $element['payment_method_all_forms'][$form_element_name], $form_state, $context);
-  }
-}
-
-/**
- * form process function that was set in hook_element_info().
- */
-function webform_paymethod_select_form_process(array $element, array &$form_state, array &$form) {
-
-  $payment          = $form_state['payment'];
-  $element['#tree'] = TRUE;
-  $pmid_options     = array();
-
-  if (!empty($element['#selected_payment_methods'])) {
-    $available_payment_methods = $payment->availablePaymentMethods(entity_load('payment_method', $element['#selected_payment_methods']));
-    foreach ($available_payment_methods as $payment_method) {
-      $pmid_options[(int) $payment_method->pmid] = check_plain(t($payment_method->title_generic));
-    }
-    $node = webform_paymethod_select_get_node($form, $form_state);
-    $context = new WebformPaymentContext(new FormState($node, $form, $form_state), $form_state);
-    drupal_alter(
-      'webform_paymethod_select_method_list',
-      $context,
-      $available_payment_methods,
-      $pmid_options
-    );
-  }
-
-  $element['#theme_wrappers'] = array('container');
-  $element['#id'] = 'paymethod-select-wrapper';
-  $element['#attributes']['class'][] = 'paymethod-select-wrapper';
-  $element['payment_method_all_forms'] = array(
-    '#type'        => 'container',
-    '#id'          => 'payment-method-all-forms',
-    '#weight'      => 2,
-    '#attributes'  => array('class' => array('payment-method-all-forms')),
-  );
-
-  if (!count($pmid_options)) {
-    if (!$payment->pid && isset($form['actions']['submit'])) {
-      // when no payment method is selected (or available) disable submit
-      // button
-      $form['actions']['submit']['#disabled'] = TRUE;
-    }
-    $element['pmid_title'] = array(
-      '#type'   => 'item',
-      '#title'  => isset($element['#title']) ? $element['#title'] : NULL,
-      '#markup' => t('There are no payment methods, check the options of this webform element to enable methods.'),
-    );
-  }
-  else {
-    reset($pmid_options);
-    $payment_method_default = isset($payment->method) ? $payment->method->pmid : key($pmid_options);
-
-    foreach ($pmid_options as $pmid => $method_name) {
-      $payment->method = $available_payment_methods[$pmid];
-      _webform_paymethod_select_get_payment_method_form($element, $form_state, $payment->method, $context);
-      unset($payment->method);
-    }
-
-    $element['payment_method_selector'] = array(
-      '#type'          => 'radios',
-      '#id'            => 'payment-method-selector',
-      '#weight'        => 1,
-      '#title'         => isset($element['#title']) ? $element['#title'] : NULL,
-      '#options'       => $pmid_options,
-      '#default_value' => $payment_method_default,
-      '#required'      => $element['#required'],
-      '#attributes'    => array('class' => array('paymethod-select-radios')),
-      '#access'        => count($pmid_options) > 1,
-    );
-  }
-  return $element;
-}
-
-/**
- * form validate callback that was set in hook_element_info().
- */
-function webform_paymethod_select_form_process_validate(array $element, array &$form_state) {
-  $payment = $form_state['payment'];
-  $values  = drupal_array_get_nested_value($form_state['values'], $element['#parents']);
-  $pmid    = (int) $values['payment_method_selector'];
-
-  $payment->method = $method = entity_load_single('payment_method', $pmid);
-  if ($payment->method->name === 'payment_method_unavailable') {
-    throw new Exception(t('Invalid Payment Method selected.'));
-  }
-
-  $node = webform_paymethod_select_get_node();
-  $context = new WebformPaymentContext(new FormState($node, $form_state['complete form'], $form_state), $form_state);
-  $payment->context_data['context'] = $context;
-
-  $method_validate_callback = $method->controller->payment_configuration_form_elements_callback . '_validate';
-  if (function_exists($method_validate_callback)) {
-    $selected_method = webform_paymethod_select_clean_name($method->controller->name);
-    $method_element = &$element['payment_method_all_forms'][$selected_method];
-    $method_validate_callback($method_element, $form_state);
-  }
-  $payment->context_data['context'] = NULL;
 }
 
 /**
@@ -275,59 +146,31 @@ function webform_paymethod_select_get_node(&$form = NULL, &$form_state = NULL) {
 }
 
 /**
- * Helper function to create and add a payment object to the form_state
- */
-function _webform_paymethod_select_set_payment(&$form_state, &$component = NULL) {
-  $config = $component ? $component['extra'] : array();
-  $config += array(
-    'line_items' => array(),
-    'payment_description' => t('Default Payment'),
-    'currency_code' => 'EUR',
-  );
-
-  $payment = new Payment(
-    array(
-      'currency_code'   => $config['currency_code'],
-      'description'     => $config['payment_description'],
-      'finish_callback' => 'webform_paymethod_select_payment_finish',
-    )
-  );
-
-  foreach ($config['line_items'] as $line_item) {
-    $payment->setLineItem($line_item);
-  }
-  $form_state['payment'] = $payment;
-}
-
-/**
- * Implements hook_form_alter().
- *
- * We need to ensure a payment object is set in $form_state['payment']
- * This alters the form for forms used by form_builder_webform
- */
-function webform_paymethod_select_form_alter(&$form, &$form_state, $form_id) {
-  if ($form_id == 'form_builder_preview' && empty($form_state['payment']) == TRUE) {
-    _webform_paymethod_select_set_payment($form_state);
-  }
-}
-
-/**
  * Implements hook_form_<BASE form ID>_alter().
  *
  * We need to ensure a payment object is set in $form_state['payment']
  * This alters all webforms using the paymethod_select webform component
  */
 function webform_paymethod_select_form_webform_client_form_alter(&$form, &$form_state, $form_id) {
-  $node = $form['#node'];
-  $webform = new Webform($node);
+  $webform = new Webform($form['#node']);
   $components = $webform->componentsByType('paymethod_select');
   if (count($components)) {
-    $component = array_pop($components);
-    if (empty($form_state['payment']) == TRUE) {
-      _webform_paymethod_select_set_payment($form_state, $component);
-    }
-    if (in_array('webform_paymethod_select_form_submit', $form['#submit']) == FALSE) {
-      $form['#submit'][] = 'webform_paymethod_select_form_submit';
+    $form['#submit'][] = 'webform_paymethod_select_form_submit';
+  }
+  foreach ($components as $cid => $component) {
+    if ($component['page_num'] == $form_state['webform']['page_num']) {
+      $parents = array($component['form_key']);
+      $parent = $component;
+      while ($parent['pid'] != 0) {
+        $parent = $components[$parent['pid']];
+        array_unshift($parents, $parent['form_key']);
+      }
+      $componentObj = &$form_state['webform_paymethod_select'][$cid];
+      if (!$componentObj) {
+        $componentObj = new Component($component);
+      }
+      $element = &drupal_array_get_nested_value($form['submitted'], $parents);
+      $componentObj->render($element, $form, $form_state);
     }
   }
 }
@@ -342,38 +185,9 @@ function webform_paymethod_select_form_webform_client_form_alter(&$form, &$form_
  */
 function webform_paymethod_select_form_submit($form, &$form_state) {
   if (!empty($form_state['webform_completed'])) {
-    $payment = &$form_state['payment'];
-    // Allow payment controllers to access the form_state.
-    $payment->form_state = &$form_state;
-    $node    = $form['#node'];
-
-    $submission = Submission::load($node->nid, $form_state['values']['details']['sid']);
-    $context = new WebformPaymentContext($submission, $form_state);
-    $payment->context_data['context'] = $context;
-
-    // handle setting the amount value in line items that were configured to
-    // not have a fixed amount
-    foreach ($payment->line_items as $line_item) {
-      if ($line_item->amount_source === 'component') {
-        $amount = $submission->valueByCid($line_item->amount_component);
-        $amount = str_replace(',', '.', $amount);
-        $line_item->amount = (float) $amount;
-      }
+    foreach ($form_state['webform_paymethod_select'] as $cid => $component) {
+      $component->submit($form, $form_state);
     }
-    entity_save('payment', $payment);
-
-    // Execute the payment.
-    if ($payment->getStatus()->status == PAYMENT_STATUS_NEW) {
-      $payment->execute();
-    }
-
-    // Set the component value to the $payment->pid - we don't save any payment data.
-    $webform = $submission->webform;
-    $cids = array_keys($webform->componentsByType('paymethod_select'));
-    db_query(
-      "UPDATE {webform_submitted_data} SET data=:pid WHERE nid=:nid AND cid IN(:cids) AND sid=:sid",
-      array(':nid' => $node->nid, ':cids' => $cids, ':sid' => $submission->sid, ':pid' => $payment->pid)
-    );
   }
 }
 
@@ -450,7 +264,7 @@ function webform_paymethod_select_node_presave($node) {
           $item->amount_component = (int) substr($item->amount_component, 4);
         }
         elseif (strpos($item->amount_component, 'new_') === 0) {
-          $element = form_builder_get_element($fcache, $item->amount_component);
+          $element = form_builder_get_element($cache, $item->amount_component);
           $item->amount_component = $element['#webform_component']['cid'];
         }
       }

--- a/webform_paymethod_select.theme.inc
+++ b/webform_paymethod_select.theme.inc
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Returns HTML for the webform_paymethod_select form_builder placeholder.
+ *
+ * @param array $variables
+ *   An associative array containing:
+ *   - element: the placeholder element with the following special keys:
+ *     - #title: The component name.
+ *     - #payment_description
+ *     - #selected_payment_methods: Enabled payment methods (pmids) for this
+ *         component.
+ *     - #currency_code: Code of the selected currency.
+ *     - #line_items: An array of payment_line_items.
+ *
+ * @ingroup themeable
+ */
+function theme_webform_paymethod_select_placeholder(&$variables) {
+  $element = &$variables['element'];
+
+  $render = array(
+    '#theme_wrappers' => array('fieldset'),
+    '#title' => $element['#title'],
+  );
+
+  $pmids = array_keys(array_filter($element['#selected_payment_methods']));
+  $methods = array();
+  foreach (entity_load('payment_method', $pmids) as $pm) {
+    $methods[] = $pm->title_specific;
+  }
+  if (!$methods) {
+    $methods[] = t('No payment method is enabled at the moment. Please enable at least one.');
+  }
+
+  $render['payment_methods'] = array(
+    '#theme' => 'item_list',
+    '#title' => t('Enabled payment methods'),
+    '#items' => $methods,
+  );
+
+  return render($render);
+}

--- a/webform_paymethod_select.webform.inc
+++ b/webform_paymethod_select.webform.inc
@@ -120,6 +120,7 @@ function _webform_edit_paymethod_select($component) {
 function _webform_render_paymethod_select($component, $value = NULL, $filter = TRUE) {
   $element = array(
     '#type' => 'container',
+    '#theme' => 'webform_paymethod_select_placeholder',
     '#title' => $component['name'],
     '#required' => TRUE,
     '#weight' => isset($component['weight']) == TRUE ? $component['weight'] : 0,
@@ -129,9 +130,6 @@ function _webform_render_paymethod_select($component, $value = NULL, $filter = T
     '#currency_code' => $component['extra']['currency_code'],
     '#line_items' => array('items' => $component['extra']['line_items']),
     '#payment_description' => $component['extra']['payment_description'],
-  );
-  $element['placeholder_info'] = array(
-    '#markup' => '<p>' . t('This is just a placeholder for the payment method selector. The actual component is rendered dynamically based on the other form elements.') . '</p>',
   );
 
   return $element;

--- a/webform_paymethod_select.webform.inc
+++ b/webform_paymethod_select.webform.inc
@@ -118,26 +118,20 @@ function _webform_edit_paymethod_select($component) {
  * Implements _webform_render_[component]().
  */
 function _webform_render_paymethod_select($component, $value = NULL, $filter = TRUE) {
-
-  $pmids = array();
-  if (!empty($component['extra']['selected_payment_methods'])) {
-    foreach ($component['extra']['selected_payment_methods'] as $pmid => $enabled) {
-      if ($enabled) {
-        $pmids[$pmid] = $pmid;
-      }
-    }
-  }
-
   $element = array(
-    '#type' => 'paymethod_select',
+    '#type' => 'container',
     '#title' => $component['name'],
     '#required' => TRUE,
-    '#selected_payment_methods' => $pmids,
     '#weight' => isset($component['weight']) == TRUE ? $component['weight'] : 0,
-    '#default_value' => array_shift($pmids),
+    // This is needed for form_builder to resave already stored values when
+    // the component's options are not touched during a form_builder session.
+    '#selected_payment_methods' => $component['extra']['selected_payment_methods'],
     '#currency_code' => $component['extra']['currency_code'],
     '#line_items' => array('items' => $component['extra']['line_items']),
     '#payment_description' => $component['extra']['payment_description'],
+  );
+  $element['placeholder_info'] = array(
+    '#markup' => '<p>' . t('This is just a placeholder for the payment method selector. The actual component is rendered dynamically based on the other form elements.') . '</p>',
   );
 
   return $element;


### PR DESCRIPTION
- Actual rendering is done in hook_form_webform_client_form_alter 
  instead of during form process (which is done a lot more often).
- Show a placeholder in form_builder instead of trying to figure
  everything out in _webform_render_component().
- All changes should be API and DB compatible.
- Insert @TODO items for API-breaking changes.
