### PR TITLE
Add quantity component

### DIFF
--- a/webform_paymethod_select.line_item.inc
+++ b/webform_paymethod_select.line_item.inc
@@ -242,6 +242,7 @@ function webform_paymethod_select_element_validate_line_item(array $element, arr
     // Convert the raw input to a PaymentLineItem object.
     $line_items[] = new \Drupal\webform_paymethod_select\PaymethodLineItem($data);
   }
+
   form_set_value($element, $line_items, $form_state);
 }
 


### PR DESCRIPTION
This code makes it possible to not only set a fixed quantity of payment but rather select a form element from which to get the quantity. Similar to the amount field.
Downside: it also clusters the already not very intuitive payment method interface.
